### PR TITLE
auth: add login and logout pages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
   "pyramid_session_redis==1.6.3",
   "redis==5.0.2",
   "waitress==3.0.0",
+  "WTForms==3.1.2",
 ]
 
 [project.license]

--- a/src/sambal/forms/__init__.py
+++ b/src/sambal/forms/__init__.py
@@ -1,0 +1,1 @@
+from .login import LoginForm

--- a/src/sambal/forms/login.py
+++ b/src/sambal/forms/login.py
@@ -1,0 +1,9 @@
+from wtforms import Form, PasswordField, StringField, SubmitField, validators
+
+
+class LoginForm(Form):
+    host = StringField("Host", [validators.DataRequired()])
+    username = StringField("Username", [validators.DataRequired()])
+    password = PasswordField("Password", [validators.DataRequired()])
+    realm = StringField("Realm")
+    login = SubmitField("Log in")

--- a/src/sambal/routes.py
+++ b/src/sambal/routes.py
@@ -1,3 +1,5 @@
 def includeme(config):
     config.add_static_view("static", "static", cache_max_age=3600)
     config.add_route("home", "/")
+    config.add_route("login", "/login/")
+    config.add_route("logout", "/logout/")

--- a/src/sambal/security.py
+++ b/src/sambal/security.py
@@ -1,7 +1,6 @@
 from typing import Optional
 
 from pyramid.authentication import AuthTktCookieHelper
-from pyramid.authorization import ACLHelper, Authenticated, Everyone
 from pyramid.interfaces import ISecurityPolicy
 from pyramid.security import forget, remember
 from samba.netcmd.domain.models import User
@@ -25,14 +24,7 @@ class SambalSecurityPolicy:
             return request.samdb.connecting_user_sid
 
     def permits(self, request, context, permission):
-        # Use the identity to build a set of principals.
-        principals = {Everyone}
-        identity = request.identity
-        if identity is not None:
-            principals.add(Authenticated)
-
-        # Pass them to the ACLHelper to determine allowed/denied.
-        return ACLHelper().permits(context, principals, permission)
+        return request.identity is not None
 
     def remember(self, request, userid, **kwargs):
         return self.authtkt.remember(request, userid, **kwargs)

--- a/src/sambal/templates/login.jinja2
+++ b/src/sambal/templates/login.jinja2
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <title>Login</title>
+</head>
+
+<body>
+  <h1>Login</h1>
+  <form action="{{ request.route_path('login') }}" method="POST">
+    <div>  
+      {{ form.username.label }} {{ form.username() }}
+      {% if form.username.errors %}
+        {% for error in form.username.errors %}
+          {{ error }}
+        {% endfor %}
+      {% endif %}
+    </div>  
+    <div>  
+      {{ form.password.label }} {{ form.password() }}
+      {% if form.username.errors %}
+        {% for error in form.username.errors %}
+          {{ error }}
+        {% endfor %}
+      {% endif %}
+    </div>  
+    <div>  
+      {{ form.host.label }} {{ form.host() }}
+      {% if form.host.errors %}
+        {% for error in form.host.errors %}
+          {{ error }}
+        {% endfor %}
+      {% endif %}
+    </div>  
+    <div>  
+      {{ form.realm.label }} {{ form.realm() }}
+      {% if form.realm.errors %}
+        {% for error in form.realm.errors %}
+          {{ error }}
+        {% endfor %}
+      {% endif %}
+    </div>
+    <div>
+      <input type="hidden" name="return_url" value="{{ return_url }}">
+      <input type="hidden" name="csrf_token" value="{{ request.session.get_csrf_token() }}">
+      {{ form.login }}
+    </div>
+  </form>
+</body>
+
+</html>

--- a/src/sambal/views/auth.py
+++ b/src/sambal/views/auth.py
@@ -1,0 +1,43 @@
+from pyramid.httpexceptions import HTTPFound
+from pyramid.view import forbidden_view_config, view_config
+
+from sambal.forms import LoginForm
+from sambal.security import login, logout
+
+
+@view_config(route_name="login", renderer="login.jinja2")
+@forbidden_view_config(accept="text/html", renderer="login.jinja2")
+def login_view(request):
+    """Login form."""
+    # Avoid looping the login page if accessed directly.
+    if request.matched_route.name == "login":
+        return_url = request.route_url("home")
+    else:
+        return_url = request.POST.get("return_url", request.url)
+
+    if request.method == "POST":
+        if (form := LoginForm(request.POST)) and form.validate():
+            username = form.username.data
+            password = form.password.data
+            host = form.host.data
+            realm = form.realm.data
+
+            if headers := login(request, username, password, host, realm):
+                return HTTPFound(location=return_url, headers=headers)
+            else:
+                request.session.flash("Login to host failed", queue="error")
+    else:
+        form = LoginForm()
+
+    return {
+        "return_url": return_url,
+        "form": form,
+    }
+
+
+@view_config(route_name="logout")
+def logout_view(request):
+    """Logout user."""
+    headers = logout(request)
+    redirect_url = request.route_url("home")
+    return HTTPFound(location=redirect_url, headers=headers)

--- a/src/sambal/views/home.py
+++ b/src/sambal/views/home.py
@@ -2,7 +2,7 @@ from pyramid.view import view_config
 from samba.netcmd.domain.models import Computer
 
 
-@view_config(route_name="home", renderer="home.jinja2")
+@view_config(route_name="home", renderer="home.jinja2", permission="read")
 def home(request):
     computers = Computer.query(request.samdb)
     return {"project": "sambal", "computers": computers, "user": request.identity}


### PR DESCRIPTION
For now the SambalSecurityPolicy.permits method just checks if request.identity is not None which is essentially "is the user logged in" regardless of the permission name used on the home view.

I wanted to push the login form first while it was in a working state, then work out ACLHelper separately.

Uses WTForms, the form is unstyled and no attention has been put towards how it looks at this point, that comes later.