### PR TITLE
login: fix redirect traversal bugs

### DIFF
--- a/src/sambal/views/auth.py
+++ b/src/sambal/views/auth.py
@@ -10,10 +10,13 @@ from sambal.forms import LoginForm
 def login(request):
     """Login form."""
     # Avoid looping the login page if accessed directly.
-    if request.matched_route.name == "login":
+    # Because the app also uses traversal request.matched_route can be None.
+    if request.method == "POST":
+        return_url = request.POST.get("return_url", request.path)
+    elif request.matched_route and request.matched_route.name == "login":
         return_url = request.route_path("home")
     else:
-        return_url = request.POST.get("return_url", request.path)
+        return_url = request.path
 
     if request.method == "POST":
         if (form := LoginForm(request.POST)) and form.validate():


### PR DESCRIPTION
Two issues this fixes:

1. When using Traversal (which hasn't been committed yet), request.matched_route will be None which crashes if you access request.matched_route.name

2. It needed to look at the request method (being POST or GET), otherwise it always ended up redirecting to request.route_path("home").

This part should never have run if the request method was POST:

    >>> return_url = request.route_path("home")

Closes #28