### PR TITLE
resource: fix container resource not including children

### DIFF
--- a/src/sambal/resources/container.py
+++ b/src/sambal/resources/container.py
@@ -1,5 +1,5 @@
 from ldb import SCOPE_ONELEVEL
-from samba.domain.models import Container
+from samba.domain.models import Container, Model
 
 from .resource import Resource
 
@@ -11,14 +11,15 @@ class ContainerResource(Resource):
         super().__init__(request, container)
 
         if request.samdb:
-            queryset = self.model.query(
+            queryset = Model.query(
                 request.samdb,
                 base_dn=container.dn,
                 scope=SCOPE_ONELEVEL,
                 polymorphic=True,
             )
 
+            self["children"] = []
             for obj in queryset:
                 if obj:
                     resource_class = self.resource_for_model(obj)
-                    self[obj.name] = resource_class(request, obj)
+                    self["children"].append(resource_class(request, obj))


### PR DESCRIPTION
The issue was that the queryset it was building was based on self.model rather than the base class: Model.

self.model was just Container, so that meant it ended up building a queryset that included only sublcasses of Container which ... is only Container, so it returned no children at all.

Also the super().__init__(request, container) call populates the Resource dict with data from the base object (the Container), so move the children under a list (using the key "children").

Closes #41