### PR TITLE
resource: fix container resource children can't be in a list

### DIFF
--- a/src/sambal/resources/container.py
+++ b/src/sambal/resources/container.py
@@ -18,8 +18,7 @@ class ContainerResource(Resource):
                 polymorphic=True,
             )
 
-            self["children"] = []
             for obj in queryset:
                 if obj:
                     resource_class = self.resource_for_model(obj)
-                    self["children"].append(resource_class(request, obj))
+                    self[obj.name] = resource_class(request, obj)


### PR DESCRIPTION
When I put the children in a list under the key "children" it completely broke traversal.

It means /Users/ worked but not /Users/<cn>/, it does now.

Fixes #44