### PR TITLE
config: add sambal entrypoint script

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,11 @@ Starting Sambal
 
 To start a development server just run:
 
-    python3 -m sambal
+    sambal
+
+or running as a module does the same:
+
+    python -m sambal
 
 The web interface can then be accessed at http://localhost:8000
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,9 @@ test = [
 [project.license]
 text = "GPL-3.0-only"
 
+[project.scripts]
+sambal = "sambal:__main__"
+
 [tool.setuptools]
 include-package-data = true
 license-files = [


### PR DESCRIPTION
you can now just run by typing "sambal" if the module is installed

Closes #40