### PR TITLE
config: setup logging

### DIFF
--- a/src/sambal/__init__.py
+++ b/src/sambal/__init__.py
@@ -1,11 +1,21 @@
+from logging import getLogger
+from logging.config import dictConfig
+
 from pyramid.config import Configurator
 from pyramid.csrf import SessionCSRFStoragePolicy
 
 from .client import get_samdb
 from .security import SambalSecurityPolicy, login, logout
-from .settings import SETTINGS
+from .settings import LOGGING, SETTINGS
 
+# Set up the logger as early as possibly.
+dictConfig(LOGGING)
+
+logger = getLogger(__name__)
+
+# Create and return a wsgi app.
 with Configurator(settings=SETTINGS) as config:
+    logger.debug("Starting sambal")
     config.include("pyramid_jinja2")
     config.include("sambal.template")
     config.include("sambal.renderers")

--- a/src/sambal/settings.py
+++ b/src/sambal/settings.py
@@ -44,3 +44,32 @@ SETTINGS = {
     "redis.sessions.cookie_httponly": True,
     "redis.sessions.cookie_secure": USE_HTTPS,
 }
+
+# Logging config.
+# https://docs.python.org/3/library/logging.config.html#logging.config.dictConfig
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": True,
+    "formatters": {
+        "standard": {"format": "%(asctime)s [%(levelname)s] %(name)s: %(message)s"},
+    },
+    "handlers": {
+        "default": {
+            "formatter": "standard",
+            "class": "logging.StreamHandler",
+            "stream": "ext://sys.stdout",
+        },
+    },
+    "loggers": {
+        "": {
+            "handlers": ["default"],
+            "level": "INFO",
+            "propagate": False,
+        },
+        "sambal": {
+            "handlers": ["default"],
+            "level": "DEBUG" if DEBUG else "INFO",
+            "propagate": False,
+        },
+    },
+}


### PR DESCRIPTION
Setup logging using dictConfig.

The default logging level is defined on the root logger and set to INFO.

Only the sambal logger is set to INFO by default, or DEBUG if the SAMBAL_DEBUG env var is set (DEBUG is on).

Closes #50