### PR TITLE
models: add support for adding newer models in the sambal source

### DIFF
--- a/src/sambal/__init__.py
+++ b/src/sambal/__init__.py
@@ -29,6 +29,7 @@ with Configurator(settings=SETTINGS) as config:
     config.add_request_method(get_samdb, "samdb", property=True, reify=True)
     config.add_request_method(login, "login")
     config.add_request_method(logout, "logout")
+    config.scan("sambal.models")
     config.scan("sambal.resources")
     config.scan("sambal.views")
     app = config.make_wsgi_app()

--- a/src/sambal/models/__init__.py
+++ b/src/sambal/models/__init__.py
@@ -1,0 +1,35 @@
+"""Sambal additional domain models.
+
+The models package provides a place for additional models that have not
+yet made it into upstream Samba.
+
+Sambal will import models from both Samba + Sambal.
+
+Any model that is declared again in Sambal overrides the one in Samba.
+"""
+
+from .application_settings import ApplicationSettings
+from .builtin import BuiltinDomain
+from .leaf import Leaf
+from .lost_and_found import LostAndFound
+from .ntfrs_settings import NTFRSSettings
+from .org import OrganizationalUnit
+from .password_settings import PasswordSettingsContainer
+from .quota import QuotaContainer
+from .secret import Secret
+from .security_object import SecurityObject
+from .tpm import TPMInformationObjectsContainer
+
+__all__ = (
+    "ApplicationSettings",
+    "BuiltinDomain",
+    "Leaf",
+    "LostAndFound",
+    "NTFRSSettings",
+    "OrganizationalUnit",
+    "PasswordSettingsContainer",
+    "QuotaContainer",
+    "Secret",
+    "SecurityObject",
+    "TPMInformationObjectsContainer",
+)

--- a/src/sambal/models/application_settings.py
+++ b/src/sambal/models/application_settings.py
@@ -1,0 +1,14 @@
+from samba.domain.models import Model
+from samba.domain.models.fields import DnField, StringField
+
+
+class ApplicationSettings(Model):
+    """ApplicationSettings base model."""
+
+    application_name = StringField("applicationName")
+    notification_list = DnField("notificationList", many=True)
+    settings = StringField("msDS-Settings")
+
+    @staticmethod
+    def get_object_class():
+        return "applicationSettings"

--- a/src/sambal/models/builtin.py
+++ b/src/sambal/models/builtin.py
@@ -1,0 +1,9 @@
+from samba.domain.models import Model
+
+
+class BuiltinDomain(Model):
+    """BuiltinDomain container model."""
+
+    @staticmethod
+    def get_object_class():
+        return "builtinDomain"

--- a/src/sambal/models/leaf.py
+++ b/src/sambal/models/leaf.py
@@ -1,0 +1,9 @@
+from samba.domain.models import Model
+
+
+class Leaf(Model):
+    """Leaf structural modal."""
+
+    @staticmethod
+    def get_object_class():
+        return "leaf"

--- a/src/sambal/models/lost_and_found.py
+++ b/src/sambal/models/lost_and_found.py
@@ -1,0 +1,9 @@
+from samba.domain.models import Model
+
+
+class LostAndFound(Model):
+    """Default container for orphaned objects."""
+
+    @staticmethod
+    def get_object_class():
+        return "lostAndFound"

--- a/src/sambal/models/ntfrs_settings.py
+++ b/src/sambal/models/ntfrs_settings.py
@@ -1,0 +1,14 @@
+from samba.domain.models.fields import BinaryField, DnField
+
+from .application_settings import ApplicationSettings
+
+
+class NTFRSSettings(ApplicationSettings):
+    """NTFRS File Replication Service settings model."""
+
+    frs_extensions = BinaryField("fRSExtensions", hidden=True)
+    managed_by = DnField("managedBy")
+
+    @staticmethod
+    def get_object_class():
+        return "nTFRSSettings"

--- a/src/sambal/models/org.py
+++ b/src/sambal/models/org.py
@@ -1,0 +1,12 @@
+from samba.domain import models
+from samba.domain.models.fields import IntegerField
+
+
+class OrganizationalUnit(models.OrganizationalUnit):
+    """OrganizationalUnit contains additional fields not in Samba yet.
+
+    This is an example where the original Samba model can be overridden.
+    The resource must be set up to use this model over the Samba one.
+    """
+
+    country_code = IntegerField("countryCode")

--- a/src/sambal/models/password_settings.py
+++ b/src/sambal/models/password_settings.py
@@ -1,0 +1,9 @@
+from samba.domain.models import Model
+
+
+class PasswordSettingsContainer(Model):
+    """PasswordSettingsContainer container model."""
+
+    @staticmethod
+    def get_object_class():
+        return "msDS-PasswordSettingsContainer"

--- a/src/sambal/models/quota.py
+++ b/src/sambal/models/quota.py
@@ -1,0 +1,16 @@
+from samba.domain.models import Model
+from samba.domain.models.fields import IntegerField, StringField
+
+
+class QuotaContainer(Model):
+    """QuotaContainer container model."""
+
+    default_quota = IntegerField("msDS-DefaultQuota")
+    tombstone_quota_factor = IntegerField("msDS-TombstoneQuotaFactor")
+    quota_effective = IntegerField("msDS-QuotaEffective", readonly=True)
+    quota_used = IntegerField("msDS-QuotaUsed", readonly=True)
+    top_quota_usage = StringField("msDS-TopQuotaUsage", many=True)
+
+    @staticmethod
+    def get_object_class():
+        return "msDS-QuotaContainer"

--- a/src/sambal/models/secret.py
+++ b/src/sambal/models/secret.py
@@ -1,0 +1,16 @@
+from samba.domain.models.fields import BinaryField, NtTimeField
+
+from .leaf import Leaf
+
+
+class Secret(Leaf):
+    """Secret model."""
+
+    current_value = BinaryField("currentValue", hidden=True)
+    last_set_time = NtTimeField("lastSetTime")
+    prior_set_time = NtTimeField("priorSetTime")
+    prior_value = BinaryField("priorValue", hidden=True)
+
+    @staticmethod
+    def get_object_class():
+        return "secret"

--- a/src/sambal/models/security_object.py
+++ b/src/sambal/models/security_object.py
@@ -1,0 +1,9 @@
+from samba.domain.models import Model
+
+
+class SecurityObject(Model):
+    """SecurityObject model."""
+
+    @staticmethod
+    def get_object_class():
+        return "securityObject"

--- a/src/sambal/models/tpm.py
+++ b/src/sambal/models/tpm.py
@@ -1,0 +1,9 @@
+from samba.domain.models import Model
+
+
+class TPMInformationObjectsContainer(Model):
+    """TPM Devices container model."""
+
+    @staticmethod
+    def get_object_class():
+        return "msTPM-InformationObjectsContainer"

--- a/src/sambal/resources/__init__.py
+++ b/src/sambal/resources/__init__.py
@@ -1,17 +1,37 @@
+from .application_settings import ApplicationSettingsResource
+from .builtin import BuiltinDomainResource
 from .computer import ComputerResource
 from .container import ContainerResource
 from .gmsa import GroupManagedServiceAccountResource
 from .group import GroupResource
+from .leaf import LeafResource
+from .lost_and_found import LostAndFoundResource
+from .org import OrganizationalUnitResource
+from .password_settings import PasswordSettingsContainerResource
+from .quota import QuotaContainerResource
 from .resource import Resource
 from .root import RootFactory
+from .secret import SecretResource
+from .security_object import SecurityObjectResource
+from .tpm import TPMInformationObjectsContainerResource
 from .user import UserResource
 
 __all__ = (
+    "ApplicationSettingsResource",
+    "BuiltinDomainResource",
     "ComputerResource",
     "ContainerResource",
     "GroupResource",
     "GroupManagedServiceAccountResource",
+    "LeafResource",
+    "LostAndFoundResource",
+    "OrganizationalUnitResource",
+    "PasswordSettingsContainerResource",
+    "QuotaContainerResource",
     "Resource",
     "RootFactory",
+    "SecretResource",
+    "SecurityObjectResource",
+    "TPMInformationObjectsContainerResource",
     "UserResource",
 )

--- a/src/sambal/resources/application_settings.py
+++ b/src/sambal/resources/application_settings.py
@@ -1,0 +1,7 @@
+from sambal.models import ApplicationSettings
+
+from .resource import Resource
+
+
+class ApplicationSettingsResource(Resource):
+    model = ApplicationSettings

--- a/src/sambal/resources/builtin.py
+++ b/src/sambal/resources/builtin.py
@@ -1,0 +1,7 @@
+from sambal.models import BuiltinDomain
+
+from .container import ContainerResource
+
+
+class BuiltinDomainResource(ContainerResource):
+    model = BuiltinDomain

--- a/src/sambal/resources/leaf.py
+++ b/src/sambal/resources/leaf.py
@@ -1,0 +1,7 @@
+from sambal.models import Leaf
+
+from .resource import Resource
+
+
+class LeafResource(Resource):
+    model = Leaf

--- a/src/sambal/resources/lost_and_found.py
+++ b/src/sambal/resources/lost_and_found.py
@@ -1,0 +1,7 @@
+from sambal.models import LostAndFound
+
+from .container import ContainerResource
+
+
+class LostAndFoundResource(ContainerResource):
+    model = LostAndFound

--- a/src/sambal/resources/org.py
+++ b/src/sambal/resources/org.py
@@ -1,0 +1,14 @@
+from samba.domain.models import OrganizationalPerson
+
+from sambal.models import OrganizationalUnit
+
+from .container import ContainerResource
+from .resource import Resource
+
+
+class OrganizationalPersonResource(Resource):
+    model = OrganizationalPerson
+
+
+class OrganizationalUnitResource(ContainerResource):
+    model = OrganizationalUnit

--- a/src/sambal/resources/password_settings.py
+++ b/src/sambal/resources/password_settings.py
@@ -1,0 +1,7 @@
+from sambal.models import PasswordSettingsContainer
+
+from .container import ContainerResource
+
+
+class PasswordSettingsContainerResource(ContainerResource):
+    model = PasswordSettingsContainer

--- a/src/sambal/resources/quota.py
+++ b/src/sambal/resources/quota.py
@@ -1,0 +1,7 @@
+from sambal.models import QuotaContainer
+
+from .container import ContainerResource
+
+
+class QuotaContainerResource(ContainerResource):
+    model = QuotaContainer

--- a/src/sambal/resources/secret.py
+++ b/src/sambal/resources/secret.py
@@ -1,0 +1,7 @@
+from sambal.models import Secret
+
+from .resource import Resource
+
+
+class SecretResource(Resource):
+    model = Secret

--- a/src/sambal/resources/security_object.py
+++ b/src/sambal/resources/security_object.py
@@ -1,0 +1,7 @@
+from sambal.models import SecurityObject
+
+from .resource import Resource
+
+
+class SecurityObjectResource(Resource):
+    model = SecurityObject

--- a/src/sambal/resources/tpm.py
+++ b/src/sambal/resources/tpm.py
@@ -1,0 +1,7 @@
+from sambal.models import TPMInformationObjectsContainer
+
+from .container import ContainerResource
+
+
+class TPMInformationObjectsContainerResource(ContainerResource):
+    model = TPMInformationObjectsContainer


### PR DESCRIPTION
Make it possible to have models in Sambal before they have been added to upstream Samba.

Models can always be donated upstream to Samba over time. As the licenses are identical there is no problem.

This just makes it quicker to get lots of models committed and tested before they make it upstream (or not).

Also, this make it possible to override models already in Samba or add new fields that aren't yet mapped in Samba (see OrganizationalUnit as an example).