### PR TITLE
config: make web application port and hostname configurable

### DIFF
--- a/src/sambal/__main__.py
+++ b/src/sambal/__main__.py
@@ -1,5 +1,5 @@
 from waitress import serve
 
-from . import app
+from . import app, SETTINGS
 
-serve(app, host="127.0.0.1", port=8000)
+serve(app, host=SETTINGS["sambal.host"], port=SETTINGS["sambal.port"])

--- a/src/sambal/settings.py
+++ b/src/sambal/settings.py
@@ -5,6 +5,8 @@ from pyramid.settings import asbool
 from redis.connection import parse_url
 
 # Read environment variables then do some sanity checks.
+HOST = os.getenv("SAMBAL_HOST", default="127.0.0.1")
+PORT = int(os.getenv("SAMBAL_PORT", default=8000))
 DEBUG = asbool(os.getenv("SAMBAL_DEBUG", default=False))
 USE_HTTPS = asbool(os.getenv("SAMBAL_HTTPS", default=False))
 USE_HSTS = asbool(os.getenv("SAMBAL_HSTS", default=False))
@@ -32,6 +34,8 @@ if SESSION_SECRET == AUTH_SECRET:
 # Pyramid settings are traditionally loaded via PasteDeploy ini file.
 # With this project we went a different way with env vars.
 SETTINGS = {
+    "sambal.host": HOST,
+    "sambal.port": PORT,
     "sambal.debug": DEBUG,
     "sambal.https": USE_HTTPS,
     "sambal.hsts": USE_HSTS,


### PR DESCRIPTION
Make web application port and hostname configurable.

* SAMBAL_HOST sets the hostname, defaulting to 127.0.0.1
* SAMBAL_PORT sets the port, defaulting to 8000

The default host shouldn't be set to 0.0.0.0, because serving on all interfaces by default isn't the best for security.

But this makes it possible for the user to set it to 0.0.0.0, or a different port.