### PR TITLE
login: fix login was working on one machine but not another

### DIFF
--- a/src/sambal/client.py
+++ b/src/sambal/client.py
@@ -24,6 +24,7 @@ def connect_samdb(host, username, password, realm=None) -> SamDB:
     lp.load_default()
 
     creds = Credentials()
+    creds.guess(lp)
     creds.set_username(username)
     creds.set_password(password)
 


### PR DESCRIPTION
After comparing with Samba's code in CredentialOptions.get_credentials, it appears the line I took out was actually needed:

    creds.guess(lp)

I took that line out initially because I didn't think it was needed, turns out I was wrong.

Closes #66